### PR TITLE
Add Learm setPosition options

### DIFF
--- a/Python/README.md
+++ b/Python/README.md
@@ -175,7 +175,7 @@ Moves one or more <em>servos</em> to a specified <em>position</em> over a <em>du
 
 When <em>servos</em> is an <em>int</em> value, it represents a servo ID and the <em>position</em> parameter is required.
 
-The <em>position</em> paramter may be an <em>int</em> to indicate a unit position (0 to 1000) or a <em>float</em> to indicate an angle in degrees (-125.0 to 125.0).
+The <em>position</em> paramter may be an <em>int</em> to indicate a unit position or a <em>float</em> to indicate an angle in degrees (-125.0 to 125.0). By default (`learm=False`), the range for unit positions is (0 to 1000), and for `learm=True`, it is 500-2500 (for all IDs from 2 to 6) and 1500-2500 for ID:1 (gripper).
 
 ```py
 # Set servo ID 1 to position 500.

--- a/Python/xarm/util.py
+++ b/Python/xarm/util.py
@@ -10,6 +10,23 @@ class Util:
     @staticmethod
     def _x_round(x):
         return float(round(x*4) / 4)
+    
+    @staticmethod
+    def _learm_joint_constraints(servo : int) -> tuple[int,int]:
+        # https://github.com/ccourson/xArmServoController/issues/5#issuecomment-1908425827
+        if servo == 1:
+            return (1500,2500)
+        elif servo in range(2,7):
+            return (500,2500)
+            
+    @staticmethod
+    def _learm_angle_to_position(servo: int, degrees : float):
+        if not isinstance(degrees, float) or degrees < -125.0 or degrees > 125.0:
+            raise ValueError('Parameter \'degrees\' must be a float value between -125.0 and 125.0')
+        x = Util._x_round(degrees)
+        y = Util._invlerp(-125.0, 125.0, x)
+        _joint_costraints : tuple[int,int] = Util._learm_joint_constraints(servo = servo)
+        return int(Util._lerp(_joint_costraints[0], _joint_costraints[1], y))
 
     @staticmethod
     def _angle_to_position(degrees):


### PR DESCRIPTION
This fixes #5 

Specifically, `Controller.setPosition` has a new argument, `learm : bool`, which is by default False. When true, it uses the LeArm 6DoF joint limits for restricting joint positions.

I tested this on my LeArm robot, this change should be backwards compatible with existing code.